### PR TITLE
Use LTO for the release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT"
 clap = "2"
 regex = "1"
 tempdir = "0.3"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Binary size

| without LTO          | with LTO             |
|----------------------|----------------------|
| 5004968 (4.8M) | 3213416 (3.1M) |
