### PR TITLE
Execute built binary in the working directory instead of the build dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT"
 clap = "2"
 regex = "1"
 tempdir = "0.3"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This PR is intended to be merged after #2, and is based on the `lto` branch. If you would prefer this to be rebased on top of the `master` branch, let me know.